### PR TITLE
Schema Endpoints now support in depth schema definitions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,24 @@
 services:
-#  api:
-#    build:
-#      context: server
-#    ports:
-#      - "8000:8000"
-#    depends_on:
-#      - mongodb
-#    volumes:
-#      - "./server:/app"  # Mount the current directory to /app in the container
-#    networks:
-#      - reservation-api
-#    command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+  api:
+    build:
+      context: server
+    ports:
+      - "8000:8000"
+    depends_on:
+      - mongodb
+    volumes:
+      - "./server:/app"  # Mount the current directory to /app in the container
+    networks:
+      - reservation-api
+    command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
 
   frontend:
     build:
       context: frontend
     ports:
       - "3000:3000"
-#    depends_on:
-#      - api
+    depends_on:
+      - api
     volumes:
       - "./frontend:/app"
       - /app/node_modules  # <-- Preserves container's node_modules

--- a/server/basemodels/schema_base_models.py
+++ b/server/basemodels/schema_base_models.py
@@ -107,8 +107,14 @@ class SchemaUpdateRequest(BaseModel):
         It is optional and can be None.
     :type fields: Optional[List[FieldDefinition]]
     """
-    name: Optional[str] = None
-    fields: Optional[List[FieldDefinition]] = None
+    schema_name: Optional[str] = None
+    fields: Optional[Dict[str, FieldDefinition]] = None
+
+    model_config = {
+        "populate_by_name": True,
+        "arbitrary_types_allowed": True,
+        "exclude_none": True
+    }
 
 
 # TODO - Update to have Object ID base basemodel

--- a/server/basemodels/schema_base_models.py
+++ b/server/basemodels/schema_base_models.py
@@ -30,7 +30,7 @@ class FieldDefinition(BaseModel):
     model_config = {
         "populate_by_name": True,
         "from_attributes": True,
-        "extra": "allow"
+        "exclude_none": True
     }
 
     type: Literal['str', 'int', 'boolean', 'float', 'list', 'date']
@@ -67,20 +67,48 @@ class FieldDefinition(BaseModel):
 
 
 class SchemaInsertRequest(BaseModel):
+    """
+    Represents a request to insert a schema.
+
+    This class is responsible for defining the structure of a schema insertion request,
+    including the schema name and its associated fields. It supports various configurations
+    for parsing the schema data and is particularly useful in applications requiring
+    schema validation and management.
+
+    :ivar schema_name: The name of the schema to be inserted.
+    :type schema_name: str
+    :ivar fields: A dictionary containing the field definitions for the schema,
+        where the keys are field names, and the values are `FieldDefinition` objects
+        describing the field's properties.
+    :type fields: Dict[str, FieldDefinition]
+    """
     schema_name: str
     fields: Dict[str, FieldDefinition]
 
     model_config = {
         "populate_by_name": True,
-        "from_attributes": True,
         "arbitrary_types_allowed": True,
-        "json_schema_extra": {"examples": [{}]},  # Optional: for OpenAPI documentation
+        "exclude_none": True
     }
 
 
 class SchemaUpdateRequest(BaseModel):
+    """
+    Represents a request to update a schema.
+
+    This class is designed to encapsulate the necessary information for
+    updating a schema, including its name and associated field definitions.
+    It leverages the Pydantic BaseModel for data validation and serialization.
+
+    :ivar name: The name of the schema to update. It is optional and can be
+        left as None if not provided.
+    :type name: Optional[str]
+    :ivar fields: A list of field definitions associated with the schema.
+        It is optional and can be None.
+    :type fields: Optional[List[FieldDefinition]]
+    """
     name: Optional[str] = None
-    parameters: Optional[List[FieldDefinition]] = None
+    fields: Optional[List[FieldDefinition]] = None
 
 
 # TODO - Update to have Object ID base basemodel
@@ -107,9 +135,10 @@ class InsertedSchema(SchemaInsertRequest):
     def serialize_object_id(self, v: ObjectId, _info):
         return str(v)
 
-    class Config:
-        populate_by_name = True
-        json_encoders = {ObjectId: str}
+    model_config = {
+        "populate_by_name": True,
+        "arbitrary_types_allowed": True
+    }
 
 
 
@@ -124,6 +153,8 @@ class CreatedSchemaResponse(BaseModel):
     def serialize_object_id(self, v: ObjectId, _info):
         return str(v)
 
-    class Config:
-        populate_by_name = True
-        json_encoders = {ObjectId: str}
+    model_config = {
+        "populate_by_name": True,
+        "arbitrary_types_allowed": True,
+        "exclude_none": True
+    }

--- a/server/main.py
+++ b/server/main.py
@@ -1,15 +1,10 @@
-from typing import Callable, Union
-from functools import wraps
-from datetime import datetime
-
 import uvicorn
-from bson import ObjectId
 from fastapi import FastAPI
 from motor.motor_asyncio import AsyncIOMotorClient
 
-from server.routes.schemarouter import router as schema_router
-from server.routes.reservationrouter import router as reservation_router  # Import the reservation router
 from server.routes.objectrouter import router as object_router  # Import the object router
+from server.routes.reservationrouter import router as reservation_router  # Import the reservation router
+from server.routes.schemarouter import router as schema_router
 from server.routes.topologyrouter import router as topology_router  # Import the topology router
 
 app = FastAPI()

--- a/server/routes/schemarouter.py
+++ b/server/routes/schemarouter.py
@@ -24,13 +24,13 @@ async def __get_schema(_id) -> InsertedSchema:
 
 
 
-@router.post("/", response_model=CreatedSchemaResponse)
+@router.post("/", response_model=CreatedSchemaResponse, response_model_exclude_none=True)
 async def create_schema(schema: SchemaInsertRequest):
     existing_schema = await collection.find_one({"name": schema.schema_name})
     if existing_schema:
         raise HTTPException(status_code=400, detail="Schema already exists")
 
-    schema_data = schema.model_dump(exclude_none=True)
+    schema_data = schema.model_dump(exclude_unset=True, exclude_none=True)
 
     now = datetime.now()
     schema_data['created_at'] = now # Add created_at field

--- a/server/routes/schemarouter.py
+++ b/server/routes/schemarouter.py
@@ -5,8 +5,8 @@ from bson import ObjectId
 from fastapi import APIRouter, HTTPException, Path, Body
 from motor.motor_asyncio import AsyncIOMotorClient
 
-from routes.basemodels import SchemaDeletedResponse, PyObjectId
-from server.routes.basemodels import CreatedSchemaResponse, SchemaInsertRequest, InsertedSchema, SchemaUpdateRequest
+from basemodels.schema_base_models import SchemaDeletedResponse, PyObjectId
+from basemodels.schema_base_models import CreatedSchemaResponse, SchemaInsertRequest, InsertedSchema, SchemaUpdateRequest
 
 router = APIRouter()
 
@@ -26,11 +26,12 @@ async def __get_schema(_id) -> InsertedSchema:
 
 @router.post("/", response_model=CreatedSchemaResponse)
 async def create_schema(schema: SchemaInsertRequest):
-    existing_schema = await collection.find_one({"name": schema.name})
+    existing_schema = await collection.find_one({"name": schema.schema_name})
     if existing_schema:
         raise HTTPException(status_code=400, detail="Schema already exists")
 
-    schema_data = schema.model_dump()
+    schema_data = schema.model_dump(exclude_none=True)
+
     now = datetime.now()
     schema_data['created_at'] = now # Add created_at field
     schema_data["updated_at"] = now

--- a/server/routes/schemarouter.py
+++ b/server/routes/schemarouter.py
@@ -47,7 +47,7 @@ async def create_schema(schema: SchemaInsertRequest):
     return res_model
 
 
-@router.get("/", response_model=List[InsertedSchema])
+@router.get("/", response_model=List[InsertedSchema], response_model_exclude_none=True)
 async def read_schemas():
     schemas = []
     async for schema in collection.find():
@@ -55,17 +55,17 @@ async def read_schemas():
     return schemas
 
 
-@router.get("/{schema_id}", response_model=InsertedSchema)
+@router.get("/{schema_id}", response_model=InsertedSchema, response_model_exclude_none=True)
 async def read_schema(schema_id: str):
     return await __get_schema(schema_id)
 
 
-@router.put("/{schema_id}", response_model=InsertedSchema)
+@router.put("/{schema_id}", response_model=InsertedSchema, response_model_exclude_none=True)
 async def update_schema(
     schema_id: Annotated[str, Path(title="The schema id to update")],
     schema: Annotated[SchemaUpdateRequest, Body(title="The parameters to be updated")]
 ):
-    update_dict = schema.model_dump()
+    update_dict = schema.model_dump(exclude_none=True)
     update_dict["updated_at"] = datetime.now()
     result = await collection.update_one({"_id": ObjectId(schema_id)}, {"$set": update_dict})
     if result.matched_count == 0:
@@ -75,7 +75,7 @@ async def update_schema(
     return latest
 
 
-@router.delete("/{schema_id}", response_model=SchemaDeletedResponse)
+@router.delete("/{schema_id}", response_model=SchemaDeletedResponse, response_model_exclude_none=True)
 async def delete_schema(schema_id: str):
     _id = PyObjectId(schema_id)
 

--- a/server/utils.py
+++ b/server/utils.py
@@ -3,6 +3,8 @@ from typing import Dict, Any, Literal, Annotated
 
 from pydantic import constr, conint, confloat, create_model, BaseModel, Field
 
+from basemodels.schema_base_models import FieldDefinition
+
 
 def datetime_as_string(d: datetime):
     return d.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -49,7 +51,7 @@ def __build_num_constraints(fields: dict, required: bool, type_name: str):
 
 def build_constrained_field(fields: Dict[str, Any]):
     type_name: str = fields.get("type")
-    required: bool = fields.get("required", False)
+    required: bool = fields.get("required", True)
     enum: list = fields.get("enum")
 
     # Handle enum fields
@@ -94,9 +96,9 @@ def build_pydantic_model(name: str, fields: Dict[str, Any]):
     return create_model(name, **model_fields)
 
 
-model = build_pydantic_model(schema["schema_name"], schema["fields"])
-model_instance = model(name="John", price=10.0, category="book")
-print("########################  SCHEMA #################################")
-print(model_instance.model_json_schema())
-print("########################  DATA  #################################")
-print(model_instance.model_dump())
+# model = build_pydantic_model(schema["schema_name"], schema["fields"])
+# model_instance = model(name="John", price=10.0, category="book")
+# print("########################  SCHEMA #################################")
+# print(model_instance.model_json_schema())
+# print("########################  DATA  #################################")
+# print(model_instance.model_dump())

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,5 +1,96 @@
 from datetime import datetime
+from typing import Dict, Any, Literal
+
+from pydantic import constr, conint, confloat, create_model, BaseModel
 
 
 def datetime_as_string(d: datetime):
     return d.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+schema = {
+    "schema_name": "schema-1",
+    "fields": {
+        "name": {
+            "type": "str",
+            "required": True,
+            "min_length": 1,
+            "max_length": 100,
+            "regex": "^[a-zA-Z0-9]+$",
+            "description": "Name of the person"
+        },
+        "price": {
+            "type": "float",
+            "required": True,
+            "min": 0.01,
+            "max": 99.9
+        },
+        "category": {
+            "type": "str",
+            "required": True,
+            "enum": ["book", "movie", "music", "sports", "other"]
+        }
+    }
+}
+
+def build_constrained_field(fields: Dict[str, Any]):
+    type_name: str = fields.get("type")
+    required: bool = fields.get("required", False)
+    enum: list = fields.get("enum")
+
+    # Create field constraints
+    field_args = {}
+    if enum:
+        return Literal[tuple(enum)], ... if required else None
+
+    if type_name == "str":
+        return (
+            constr(
+                min_length=fields.get("min_length"),
+                max_length=fields.get("max_length"),
+                pattern=fields.get("regex")
+            ),
+            ... if required else None,
+        )
+
+    if type_name == "int":
+        return (
+            conint(
+                ge=fields.get("min"),
+                le=fields.get("max")
+            ),
+            ... if required else None,
+        )
+
+    if type_name == "float":
+        return confloat(
+            ge=fields.get("min"),
+            le=fields.get("max")
+        )
+
+    base_type = {
+        "str": str,
+        "int": int,
+        "float": float,
+        "bool": bool
+    }.get(type_name, str)
+
+    return base_type, ... if required else None
+
+
+def build_pydantic_model(name: str, fields: Dict[str, Any]):
+    model_fields = {}
+
+    for field_name, field_def in fields.items():
+        model_fields[field_name] = build_constrained_field(field_def)
+
+
+    return create_model(name, **model_fields)
+
+
+model = build_pydantic_model(schema["schema_name"], schema["fields"])
+model_instance = model(name="John", price=10.0, category="book")
+print("########################  SCHEMA #################################")
+print(model_instance.model_json_schema())
+print("########################  DATA  #################################")
+print(model_instance.model_dump())


### PR DESCRIPTION
Schema Endpoints now support in depth schema definitions.

1. Define all parameters required to create an object
2. Define their datatypes and various constraints, i.e. regex, enum, min, max etc